### PR TITLE
Dont show xpbuddy in the console when no XP points have been accounted

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -25,7 +25,9 @@ function Addon:PLAYER_ENTERING_WORLD()
         self.current_instance:start()
     elseif self.current_instance then
         self.current_instance:stop()
-        print(self.current_instance:toString())
+        if self.current_instance:hasXp() then
+            print(self.current_instance:toString())
+        end
         self.current_instance = nil
     end
 end
@@ -42,7 +44,9 @@ function Addon:UNIT_PET()
 
     if self.current_pet and self.current_pet.name ~= pet_name then
         self.current_pet:stop()
-        print(self.current_pet:toString())
+        if self.current_pet:hasXp() then
+            print(self.current_pet:toString())
+        end
         self.current_pet = nil
     end
 

--- a/src/meter.lua
+++ b/src/meter.lua
@@ -119,3 +119,7 @@ function XPMeter:stop()
         self.stopped = true
     end
 end
+
+function XPMeter:hasXp()
+    return self.total_gained_xp > 0
+end

--- a/tests/test_pet.lua
+++ b/tests/test_pet.lua
@@ -4,6 +4,7 @@ function test_pet_summon_dismiss()
     assertEqual(0, #Addon.pets)
 
     -- Summon Pet
+    GetPetExperience_VALUE = {0, 3600}
     GetTime_VALUE = {10}
     UnitName_VALUE = {"Leo"}
     Addon:UNIT_PET()
@@ -14,20 +15,22 @@ function test_pet_summon_dismiss()
     -- Dismiss Pet
     GetTime_VALUE = {20}
     UnitName_VALUE = {nil}
+    GetPetExperience_VALUE = {60, 3600}
+    Addon:UNIT_PET_EXPERIENCE()
     Addon:UNIT_PET()
     assert(Addon.pets["Leo"] ~= nil, "Expected to have a pet named Leo")
     assertEqual(nil, Addon.current_pet)
     assertEqual(10, Addon.pets["Leo"]:totalTime())
     -- When the pet is dimissed, we should have a message on the console
     assertEqual(1, #Console)
-    assertEqual("Leo (0:00:10) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)", Console[1])
+    assertEqual("Leo (0:00:10) Gained 60xp (360xp/min) / Lvl: 2% (600%/h)", Console[1])
 
     -- Calling the slash command
     SlashCmdList["XPBUDDY"]()
     assertEqual(4, #Console)
     assertEqual("Session (0:00:20) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)", Console[2])
     assertEqual("Pets:", Console[3])
-    assertEqual("- Leo (0:00:10) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)", Console[4])
+    assertEqual("- Leo (0:00:10) Gained 60xp (360xp/min) / Lvl: 2% (600%/h)", Console[4])
 end
 
 function test_change_pet()
@@ -51,18 +54,27 @@ function test_change_pet()
     assertEqual(Addon.pets["Stan"], Addon.current_pet)
     assertEqual(10, Addon.pets["Leo"]:totalTime())
     assertEqual(0, Addon.pets["Stan"]:totalTime())
-    -- When the pet is dimissed, we should have a message on the console
-    assertEqual(1, #Console)
-    assertEqual("Leo (0:00:10) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)", Console[1])
+    -- When the pet is dimissed without xp, we should not have any message on the console
+    assertEqual(0, #Console)
     
     -- Calling the slash command
     SlashCmdList["XPBUDDY"]()
-    assertEqual(5, #Console)
-    assertEqual("Session (0:00:20) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)", Console[2])
-    assertEqual("Pets:", Console[3])
+    assertEqual(4, #Console)
+    assertEqual("Session (0:00:20) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)", Console[1])
+    assertEqual("Pets:", Console[2])
 
     -- Order of elements is not fixed in a key=value Lua table, so the table
     -- pets={pet_name = meter} can be printed in any order
     assertConsoleContains("- Leo (0:00:10) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)")
     assertConsoleContains("- Stan (0:00:00) Gained 0xp (0xp/min) / Lvl: 0% (0%/h)")
+end
+
+function test_no_print_when_no_xp_gain_from_pet()
+    UnitName_VALUE = {"Leo"}
+    Addon:UNIT_PET()
+    assertEqual(0, #Console)
+
+    UnitName_VALUE = {nil}
+    Addon:UNIT_PET()
+    assertEqual(0, #Console)
 end

--- a/tests/test_player.lua
+++ b/tests/test_player.lua
@@ -96,3 +96,15 @@ function test_gain_xp_from_mid_level()
     Addon:PLAYER_XP_UPDATE()
     assertEqual(20, Addon.session.total_gained_xp)
 end
+
+function test_no_print_when_no_xp_gain_in_instance()
+    IsInInstance_VALUE = {true}
+    GetInstanceInfo_VALUE = {"BRD"}
+    Addon:PLAYER_ENTERING_WORLD()
+    assertEqual(0, #Console)
+
+    IsInInstance_VALUE = {false}
+    GetInstanceInfo_VALUE = {"Azeroth"}
+    Addon:PLAYER_ENTERING_WORLD()
+    assertEqual(0, #Console)
+end


### PR DESCRIPTION
Signed-off-by: iTitou <moiandme@gmail.com>
